### PR TITLE
chore(option): add "ansibleServer.trace.server"

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You can also run the installation command manually.
 - `ansible.ansibleNavigator.path`: Points to the ansible-navigator executable, default: `"ansible-navigator"`
 - `ansible.ansiblePlaybook.path`: Points to the ansible-playbook executable, default: `"ansible-playbook"`
 - `ansible.dev.serverPath`: Absolute path to ansible language server module. If it is not set, use the extention's server module. (For develop and check), default: `""`
+- `ansibleServer.trace.server`: Traces the communication between coc.nvim and the ansible language server, default: `"off"`
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -233,6 +233,16 @@
           "type": "string",
           "default": "",
           "description": "Absolute path to ansible language server module. If it is not set, use the extention's server module. (For develop and check)"
+        },
+        "ansibleServer.trace.server": {
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between coc.nvim and the ansible language server."
         }
       }
     },


### PR DESCRIPTION
## Description

Add the `*.trace.server` setting to the configuration option, so that configuration completion also works in `coc-settings.json`. (In the case of vscode, it's `settings.json`)

Added with reference to `vscode-yaml`. https://github.com/redhat-developer/vscode-yaml/blob/main/package.json#L98-L107

## DEMO

https://user-images.githubusercontent.com/188642/138537321-b75037d1-760d-4c8f-86c0-c9feb861e250.mp4

## Misc

I am wondering if it would be better to change to `ansible` instead of `ansibleServer`.

adjust here if you want to change it. https://github.com/yaegassy/coc-ansible/blob/master/src/index.ts#L175
