### PR TITLE
feat(command): add "ansible.server.restart" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ You can also run the installation command manually.
       - `~/AppData/Local/coc/extensions/@yaegassy/coc-ansible-data/ansible/venv/Scripts/ansible-lint.exe`
       - `~/AppData/Local/coc/extensions/@yaegassy/coc-ansible-data/ansible/venv/Scripts/yamllint.exe`
   - **[Note]** `ansible` is a very large tool and will take some time to install
+- `ansible.server.restart`: Restart ansible language server
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -252,6 +252,10 @@
         "title": "Install ansible, ansible-lint and yamllint(optional) with extension's venv"
       },
       {
+        "command": "ansible.server.restart",
+        "title": "Restart ansible language server"
+      },
+      {
         "command": "ansible.ansible-playbook.run",
         "title": "Run playbook via `ansible-playbook`"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,18 @@ export async function activate(context: ExtensionContext): Promise<void> {
     })
   );
 
+  context.subscriptions.push(
+    commands.registerCommand('ansible.server.restart', async () => {
+      // Refresh the diagnostics by setting undefined for coc.nvim
+      const { document } = await workspace.getCurrentState();
+      client.diagnostics?.set(document.uri, undefined);
+
+      // Stop and Start
+      await client.stop();
+      client.start();
+    })
+  );
+
   let serverModule: string;
   const devServerPath = extensionConfig.get<string>('dev.serverPath', '');
   if (devServerPath && devServerPath !== '' && fs.existsSync(devServerPath)) {


### PR DESCRIPTION
## Description

It would be useful to have a command to restart only `ansible-langauge-server`.

## DEMO (mp4)

https://user-images.githubusercontent.com/188642/138575504-ca9d1bbe-2496-4a4f-897d-33f4a5e1bfa0.mp4
