### PR TITLE
chore(doc): add that g:coc_filetype_map is required to enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,19 @@ Plug 'yaegassy/coc-ansible', {'do': 'yarn install --frozen-lockfile'}
 
 ## Note
 
-### Filetype related
+### [!! Very important !!] Filetype related
 
-The "filetype" must be `yaml.ansible` for this extension to work.
+1. The "filetype" must be `yaml.ansible` for this extension to work.
 
-If you install ansible's vim plugin, `yaml.ansible` filetype will be added automatically, which is very useful (e.g. [pearofducks/ansible-vim](https://github.com/pearofducks/ansible-vim) or [sheerun/vim-polyglot](https://github.com/sheerun/vim-polyglot)).
+   If you install ansible's vim plugin, `yaml.ansible` filetype will be added automatically, which is very useful (e.g. [pearofducks/ansible-vim](https://github.com/pearofducks/ansible-vim) or [sheerun/vim-polyglot](https://github.com/sheerun/vim-polyglot)).
+
+2. You also need to set `g:coc_filetype_map` in `.vimrc/init.vim`.
+
+   ```vim
+   let g:coc_filetype_map = {
+     \ 'yaml.ansible': 'ansible',
+     \ }
+   ```
 
 ## Requirements (Tools)
 


### PR DESCRIPTION
## Description

There has been a change in the behavior of coc.nvim since this commit. <https://github.com/neoclide/coc.nvim/commit/54447acfe7f19daab029457cd30fe242243f47b5>

It seems to have been added from a feature request. <https://github.com/neoclide/coc.nvim/issues/3358>

The `yaml.ansible` filetype has been changed to be recognized by `yaml` languageId.

coc-ansible is intentionally not working with yaml filetypes.

---

As a countermeasure to this change, we will set our own "languageId" called `ansible` to use it.

```vim
let g:coc_filetype_map = {
  \ 'yaml.ansible': 'ansible',
  \ }
```

Added `g:coc_filetype_map` setting to README.

## Misc

As a side note, It seems that I had made it so that I could start with the languageId `ansible` from the beginning.

- <https://github.com/yaegassy/coc-ansible/blob/master/package.json#L53>
- <https://github.com/yaegassy/coc-ansible/blob/master/src/index.ts#L178>
