### PR TITLE
add a flag to always use builtin tools installed in the extension venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ You can also run the installation command manually.
 - `ansible.builtin.isWithYamllint`: Whether to install yamllint the built-in installer, default: `false`
 - `ansible.builtin.ansibleVersion`: Version of `ansible` for built-in install, default: `""`
 - `ansible.builtin.ansibleLintVersion`: Version of `ansible-lint` for built-in install, default: `""`
+- `ansible.builtin.force`: Whether to force builtin tools instead those in the PATH, default: `false`
 - `ansible.builtin.yamllintVersion`: Version of `yamllint` for built-in install, default: `""`
 - `ansible.ansible.useFullyQualifiedCollectionNames`: Always use fully qualified collection names (FQCN) when inserting a module name. Disabling it will only use FQCNs when necessary, default: `true`
 - `ansible.ansibleLint.arguments`: Command line arguments to be passed to ansible-lint, default: `""`

--- a/package.json
+++ b/package.json
@@ -172,6 +172,11 @@
           "default": "",
           "description": "Version of ansible-lint for built-in install."
         },
+        "ansible.builtin.force": {
+          "type": "string",
+          "default": "",
+          "description": "Whether to force builtin tools instead those in the PATH"
+        },
         "ansible.builtin.yamllintVersion": {
           "type": "string",
           "default": "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,6 @@ let pythonInterpreterPath: string;
 let existsAnsibleCmd: boolean;
 let existsAnsibleLintCmd: boolean;
 let ansibleLintModule: boolean;
-let forceBuiltinTools: boolean;
 
 // MEMO: client logging
 const outputChannel = window.createOutputChannel('ansible-client');

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ let pythonInterpreterPath: string;
 let existsAnsibleCmd: boolean;
 let existsAnsibleLintCmd: boolean;
 let ansibleLintModule: boolean;
+let forceBuiltinTools: boolean;
 
 // MEMO: client logging
 const outputChannel = window.createOutputChannel('ansible-client');
@@ -54,6 +55,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   const ansiblePath = extensionConfig.get('ansible.path', 'ansible');
   const ansibleLintPath = extensionConfig.get('ansibleLint.path', 'ansible-lint');
+  const forceBuiltinTools = extensionConfig.get('builtin.force', false);
 
   pythonInterpreterPath = extensionConfig.get('python.interpreterPath', '');
 
@@ -66,13 +68,14 @@ export async function activate(context: ExtensionContext): Promise<void> {
   outputChannel.appendLine(`pythonInterpreterPath(custom): ${pythonInterpreterPath ? pythonInterpreterPath : 'None'}`);
   outputChannel.appendLine(`existsAnsibleCmd: ${existsAnsibleCmd}`);
   outputChannel.appendLine(`existsAnsibleLintCmd: ${existsAnsibleLintCmd}`);
+  outputChannel.appendLine(`forceBuiltinTools: ${forceBuiltinTools}`);
 
   let existsExtAnsibleCmd = false;
   let ansibleBuiltinPath = '';
   let ansibleLintBuiltinPath = '';
 
   if (!pythonInterpreterPath) {
-    if (!existsAnsibleCmd || !existsAnsibleLintCmd) {
+    if (!existsAnsibleCmd || !existsAnsibleLintCmd || forceBuiltinTools) {
       ansibleBuiltinPath = getBuiltinToolPath(extensionStoragePath, 'ansible');
       ansibleLintBuiltinPath = getBuiltinToolPath(extensionStoragePath, 'ansible-lint');
       if (ansibleBuiltinPath) {


### PR DESCRIPTION
Hello, I'm new to JavaScript, so I'm sorry in advance :)
I'm using nvim in several separate installations and would like to add an option to always use tools from venv instead of system ones.
I've added a config option and basic logic