### PR TITLE
feat: add "Show web documentation" code action

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ In the line with diagnostic message, enter the mapped key (e.g. `ga`) and you wi
 **Actions**:
 
 - `Ignoring rules for current line (# noqa [ruleId])` | [DEMO](https://github.com/yaegassy/coc-ansible/pull/13)
-- `Show web documentation for [ruleId]`
+- `Show web documentation for [ruleId]` | [DEMO](https://github.com/yaegassy/coc-ansible/pull/21#issue-1296813716)
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ In the line with diagnostic message, enter the mapped key (e.g. `ga`) and you wi
 **Actions**:
 
 - `Ignoring rules for current line (# noqa [ruleId])` | [DEMO](https://github.com/yaegassy/coc-ansible/pull/13)
+- `Show web documentation for [ruleId]`
 
 ## Thanks
 

--- a/package.json
+++ b/package.json
@@ -335,14 +335,6 @@
       {
         "command": "ansible.server.restart",
         "title": "Restart ansible language server"
-      },
-      {
-        "command": "ansible.ansible-playbook.run",
-        "title": "Run playbook via `ansible-playbook`"
-      },
-      {
-        "command": "ansible.ansible-navigator.run",
-        "title": "Run playbook via `ansible-navigator run`"
       }
     ]
   },

--- a/src/actions/showWebDocumentation.ts
+++ b/src/actions/showWebDocumentation.ts
@@ -50,7 +50,7 @@ class ShowWebDocumentationCodeActionProvider implements CodeActionProvider {
     }
     const codeActions: CodeAction[] = [];
 
-    /** Show web documentation for ${r} */
+    /** Show web documentation for [ruleId] */
     if (this.lineRange(range) && context.diagnostics.length > 0) {
       const line = doc.getline(range.start.line);
       if (line && line.length) {

--- a/src/actions/showWebDocumentation.ts
+++ b/src/actions/showWebDocumentation.ts
@@ -1,0 +1,98 @@
+import {
+  CodeAction,
+  CodeActionContext,
+  CodeActionProvider,
+  DocumentSelector,
+  ExtensionContext,
+  languages,
+  OutputChannel,
+  Range,
+  TextDocument,
+  workspace,
+} from 'coc.nvim';
+
+export function activate(context: ExtensionContext, outputChannel: OutputChannel) {
+  const documentSelector: DocumentSelector = [
+    { scheme: 'file', language: 'ansible' },
+    { scheme: 'file', language: 'yaml.ansible' },
+  ];
+
+  context.subscriptions.push(
+    languages.registerCodeActionProvider(
+      documentSelector,
+      new ShowWebDocumentationCodeActionProvider(outputChannel),
+      'ansible'
+    )
+  );
+}
+
+class ShowWebDocumentationCodeActionProvider implements CodeActionProvider {
+  private readonly source = 'ansible';
+  private diagnosticCollection = languages.createDiagnosticCollection(this.source);
+  private outputChannel: OutputChannel;
+
+  constructor(outputChannel: OutputChannel) {
+    this.outputChannel = outputChannel;
+  }
+
+  public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext) {
+    const doc = workspace.getDocument(document.uri);
+    const wholeRange = Range.create(0, 0, doc.lineCount, 0);
+    let whole = false;
+    if (
+      range.start.line === wholeRange.start.line &&
+      range.start.character === wholeRange.start.character &&
+      range.end.line === wholeRange.end.line &&
+      range.end.character === wholeRange.end.character
+    ) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      whole = true;
+    }
+    const codeActions: CodeAction[] = [];
+
+    /** Show web documentation for ${r} */
+    if (this.lineRange(range) && context.diagnostics.length > 0) {
+      const line = doc.getline(range.start.line);
+      if (line && line.length) {
+        let existsAnsibleDiagnostics = false;
+        const ruleIds: string[] = [];
+        context.diagnostics.forEach((d) => {
+          if (d.source === 'Ansible') {
+            existsAnsibleDiagnostics = true;
+            const ruleId = d.message.split('\n')[0];
+            if (ruleId) ruleIds.push(ruleId);
+          }
+        });
+
+        if (existsAnsibleDiagnostics) {
+          ruleIds.forEach((r) => {
+            const title = `Show web documentation for ${r}`;
+            const url = `https://ansible-lint.readthedocs.io/en/latest/default_rules/#${r}`;
+
+            const command = {
+              title: '',
+              command: 'vscode.open',
+              arguments: [url],
+            };
+
+            const action: CodeAction = {
+              title,
+              command,
+            };
+
+            codeActions.push(action);
+          });
+        }
+      }
+    }
+
+    return codeActions;
+  }
+
+  private lineRange(r: Range): boolean {
+    return (
+      (r.start.line + 1 === r.end.line && r.start.character === 0 && r.end.character === 0) ||
+      (r.start.line === r.end.line && r.start.character === 0)
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
 } from './tool';
 
 import * as ignoringRulesCodeActionFeature from './actions/ignoringRules';
+import * as showWebDocumentationCodeActionFeature from './actions/showWebDocumentation';
 import * as builtinInstallRequirementsToolsCommandFeature from './commands/builtinInstallRequirementsTools';
 import * as serverRestartCommandFeature from './commands/serverRestart';
 
@@ -169,6 +170,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   if (pythonCommandPaths) builtinInstallRequirementsToolsCommandFeature.activate(context, pythonCommandPaths, client);
   serverRestartCommandFeature.activate(context, client);
   ignoringRulesCodeActionFeature.activate(context, outputChannel);
+  showWebDocumentationCodeActionFeature.activate(context, outputChannel);
 }
 
 export function deactivate(): Thenable<void> | undefined {


### PR DESCRIPTION
## Description

The feature to open the `ansible-lint` rules documentation page in a "browser" based on the diagnostic message.

- https://ansible-lint.readthedocs.io/en/latest/default_rules/

## DEMO (mp4)

https://user-images.githubusercontent.com/188642/177694460-bcc3adc6-6af7-4e07-9709-da1487d34aaf.mp4
