### PR TITLE
feat: add ansible-doc integration feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ You can also run the installation command manually.
 - `ansible.completion.provideRedirectModules`: Toggle redirected module provider when completing modules, default: `true`
 - `ansible.completion.provideModuleOptionAliases`: Toggle alias provider when completing module options, default: `true`
 - `ansible.python.interpreterPath`: Path to the Python interpreter executable. Particularly important if you are using a Python virtual environment. Leave blank to use Python from PATH. **In coc-ansible, the default value is blank**, default: `""`
+- `ansible.ansibleDoc.path`: Path to the ansible-doc executable, default: `ansible-doc`
+- `ansible.ansibleDoc.enableSplitRight`: Use vertical belowright for ansible-doc terminal window, default: `true`
 - `ansible.ansibleNavigator.path`: Points to the ansible-navigator executable, default: `"ansible-navigator"`
 - `ansible.dev.serverPath`: Absolute path to ansible language server module. If it is not set, use the extention's server module. (For develop and check), default: `""`
 - `ansibleServer.trace.server`: Traces the communication between coc.nvim and the ansible language server, default: `"off"`
@@ -96,6 +98,8 @@ You can also run the installation command manually.
       - `~/AppData/Local/coc/extensions/@yaegassy/coc-ansible-data/ansible/venv/Scripts/yamllint.exe`
   - **[Note]** `ansible` is a very large tool and will take some time to install
 - `ansible.server.restart`: Restart ansible language server
+- `ansible.ansbileDoc.showInfo`: Run the `ansible-doc` command in a terminal window with various options to display information about the plugins
+- `ansible.ansbileDoc.showSnippets`: Run the `ansible-doc` command in a terminal window with various options to display a snippets of the plugins.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ You can also run the installation command manually.
 
 ## Commands
 
+**Command List**:
+
+> :CocCommand [CommandName]
+>
+> **e.g.** :CocCommand ansible.server.restart
+
 - `ansible.builtin.installRequirementsTools`: Install `ansible`, `ansible-lint` and `yamllint` (optional) with extension's venv
   - It will be installed in this path:
     - Mac/Linux:
@@ -98,10 +104,15 @@ You can also run the installation command manually.
       - `~/AppData/Local/coc/extensions/@yaegassy/coc-ansible-data/ansible/venv/Scripts/yamllint.exe`
   - **[Note]** `ansible` is a very large tool and will take some time to install
 - `ansible.server.restart`: Restart ansible language server
-- `ansible.ansbileDoc.showInfo`: Run the `ansible-doc` command in a terminal window with various options to display information about the plugins
-- `ansible.ansbileDoc.showSnippets`: Run the `ansible-doc` command in a terminal window with various options to display a snippets of the plugins.
+- `ansible.ansbileDoc.showInfo`: Run the `ansible-doc` command in a terminal window with various options to display information about the plugins | [DEMO](https://github.com/yaegassy/coc-ansible/pull/22#issuecomment-1178586815)
+- `ansible.ansbileDoc.showSnippets`: Run the `ansible-doc` command in a terminal window with various options to display a snippets of the plugins | [DEMO](https://github.com/yaegassy/coc-ansible/pull/22#issuecomment-1178587359)
 
----
+**Example of command key mapping**:
+
+```vim
+" Quickly view a list of all coc.nvim commands
+nnoremap <silent> <C-p> :<C-u>CocCommand<CR>
+```
 
 ## Code Actions
 

--- a/package.json
+++ b/package.json
@@ -212,6 +212,17 @@
           "default": "ansible-lint",
           "description": "Path to the ansible-lint executable."
         },
+        "ansible.ansibleDoc.path": {
+          "scope": "resource",
+          "type": "string",
+          "default": "ansible-doc",
+          "description": "Path to the ansible-doc executable."
+        },
+        "ansible.ansibleDoc.enableSplitRight": {
+          "type": "boolean",
+          "default": true,
+          "description": "Use vertical belowright for ansible-doc terminal window."
+        },
         "ansible.ansibleNavigator.path": {
           "default": "ansible-navigator",
           "description": "Points to the ansible-navigator executable.",
@@ -335,6 +346,14 @@
       {
         "command": "ansible.server.restart",
         "title": "Restart ansible language server"
+      },
+      {
+        "command": "ansible.ansbileDoc.showInfo",
+        "title": "Run the `ansible-doc` command in a terminal window with various options to display information about the plugins"
+      },
+      {
+        "command": "ansible.ansbileDoc.showSnippets",
+        "title": "Run the `ansible-doc` command in a terminal window with various options to display a snippets of the plugins."
       }
     ]
   },

--- a/src/commands/ansibleDocShowInfo.ts
+++ b/src/commands/ansibleDocShowInfo.ts
@@ -1,0 +1,134 @@
+import {
+  BasicList,
+  commands,
+  ExtensionContext,
+  ListAction,
+  ListContext,
+  ListItem,
+  listManager,
+  Neovim,
+  Terminal,
+  window,
+  workspace,
+} from 'coc.nvim';
+
+import cp from 'child_process';
+
+let terminal: Terminal | undefined;
+
+type FeatureListItemType = {
+  name: string;
+  description: string;
+};
+
+export function activate(context: ExtensionContext, ansibleDocPath: string) {
+  const ansibleDocList = new AnsibleDocShowInfoList(workspace.nvim, ansibleDocPath);
+  listManager.registerList(ansibleDocList);
+
+  context.subscriptions.push(
+    commands.registerCommand('ansible.ansbileDoc.showInfo', async () => {
+      const pluginType = [
+        'module',
+        'become',
+        'cache',
+        'callback',
+        'cliconf',
+        'connection',
+        'httpapi',
+        'inventory',
+        'lookup',
+        'netconf',
+        'shell',
+        'vars',
+        'strategy',
+        'role',
+        'keyword',
+      ];
+
+      const picked = await window.showMenuPicker(pluginType, `Choose Plugin Type`);
+
+      if (picked !== -1) {
+        ansibleDocList.choosedPluginType = pluginType[picked];
+        await workspace.nvim.command(`CocList ansibleDocShowInfo`);
+      }
+    })
+  );
+}
+
+class AnsibleDocShowInfoList extends BasicList {
+  public readonly name = 'ansibleDocShowInfo';
+  public readonly description = 'information for ansible-doc';
+  public readonly defaultAction = 'execute';
+  public actions: ListAction[] = [];
+
+  public ansibleDocPath: string;
+  public choosedPluginType = 'module';
+
+  constructor(nvim: Neovim, ansibleDocPath: string) {
+    super(nvim);
+
+    this.ansibleDocPath = ansibleDocPath;
+
+    this.addAction('execute', (item: ListItem) => {
+      const pluginName = item.label.split(':')[0];
+      runAnsibleDocShowInfoInTerminal(pluginName, this.ansibleDocPath, this.choosedPluginType);
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public async loadItems(context: ListContext): Promise<ListItem[]> {
+    const listItems: ListItem[] = [];
+    const plugins = await getAnsibleDocListItems(this.ansibleDocPath, this.choosedPluginType);
+    plugins.forEach((p) => listItems.push({ label: `${p.name}: [${p.description}]`, filterText: p.name }));
+    return listItems;
+  }
+}
+
+async function getAnsibleDocListItems(ansibleDocPath: string, pluginType: string) {
+  return new Promise<FeatureListItemType[]>((resolve) => {
+    cp.exec(`${ansibleDocPath} -l -j -t ${pluginType}`, (err, stdout) => {
+      if (err) resolve([]);
+
+      if (stdout.length > 0) {
+        try {
+          const ansibleDocListJSONData = JSON.parse(stdout);
+          const featureResults: FeatureListItemType[] = [];
+          Object.keys(ansibleDocListJSONData).forEach((key) => {
+            featureResults.push({
+              name: key,
+              description: ansibleDocListJSONData[key],
+            });
+          });
+          resolve(featureResults);
+        } catch (e) {
+          resolve([]);
+        }
+      } else {
+        resolve([]);
+      }
+    });
+  });
+}
+
+async function runAnsibleDocShowInfoInTerminal(pluginName: string, ansibleDocPath: string, choosedPluginType: string) {
+  const args: string[] = [];
+  args.push('-t', choosedPluginType);
+  args.push(pluginName);
+
+  if (terminal) {
+    if (terminal.bufnr) {
+      await workspace.nvim.command(`bd! ${terminal.bufnr}`);
+    }
+    terminal.dispose();
+    terminal = undefined;
+  }
+  terminal = await window.createTerminal({ name: 'ansibleDocShowInfo', cwd: workspace.root });
+  terminal.sendText(`${ansibleDocPath} ${args.join(' ')}`);
+  const enableSplitRight = workspace.getConfiguration('ansible').get('ansibleDoc.enableSplitRight', true);
+  if (enableSplitRight) terminal.hide();
+  await workspace.nvim.command('stopinsert');
+  if (enableSplitRight) {
+    await workspace.nvim.command(`vert bel sb ${terminal.bufnr}`);
+    await workspace.nvim.command(`wincmd p`);
+  }
+}

--- a/src/commands/ansibleDocShowSnippets.ts
+++ b/src/commands/ansibleDocShowSnippets.ts
@@ -1,0 +1,125 @@
+import {
+  BasicList,
+  commands,
+  ExtensionContext,
+  ListAction,
+  ListContext,
+  ListItem,
+  listManager,
+  Neovim,
+  Terminal,
+  window,
+  workspace,
+} from 'coc.nvim';
+
+import cp from 'child_process';
+
+let terminal: Terminal | undefined;
+
+type FeatureListItemType = {
+  name: string;
+  description: string;
+};
+
+export function activate(context: ExtensionContext, ansibleDocPath: string) {
+  const ansibleDocList = new AnsibleDocShowSnippetsList(workspace.nvim, ansibleDocPath);
+  listManager.registerList(ansibleDocList);
+
+  context.subscriptions.push(
+    commands.registerCommand('ansible.ansbileDoc.showSnippets', async () => {
+      // Only snippets is module, inventory and lookup are supported.
+      // See: https://docs.ansible.com/ansible/latest/cli/ansible-doc.html
+      const pluginType = ['module', 'inventory', 'lookup'];
+
+      const picked = await window.showMenuPicker(pluginType, `Choose Plugin Type`);
+
+      if (picked !== -1) {
+        ansibleDocList.choosedPluginType = pluginType[picked];
+        await workspace.nvim.command(`CocList ansibleDocShowSnippets`);
+      }
+    })
+  );
+}
+
+class AnsibleDocShowSnippetsList extends BasicList {
+  public readonly name = 'ansibleDocShowSnippets';
+  public readonly description = 'snippets for ansible-doc';
+  public readonly defaultAction = 'execute';
+  public actions: ListAction[] = [];
+
+  public ansibleDocPath: string;
+  public choosedPluginType = 'module';
+
+  constructor(nvim: Neovim, ansibleDocPath: string) {
+    super(nvim);
+
+    this.ansibleDocPath = ansibleDocPath;
+
+    this.addAction('execute', (item: ListItem) => {
+      const pluginName = item.label.split(':')[0];
+      runAnsibleDocShowSnippetsInTerminal(pluginName, this.ansibleDocPath, this.choosedPluginType);
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public async loadItems(context: ListContext): Promise<ListItem[]> {
+    const listItems: ListItem[] = [];
+    const plugins = await getAnsibleDocListItems(this.ansibleDocPath, this.choosedPluginType);
+    plugins.forEach((p) => listItems.push({ label: `${p.name}: [${p.description}]`, filterText: p.name }));
+    return listItems;
+  }
+}
+
+async function getAnsibleDocListItems(ansibleDocPath: string, pluginType: string) {
+  return new Promise<FeatureListItemType[]>((resolve) => {
+    cp.exec(`${ansibleDocPath} -l -j -t ${pluginType}`, (err, stdout) => {
+      if (err) resolve([]);
+
+      if (stdout.length > 0) {
+        try {
+          const ansibleDocListJSONData = JSON.parse(stdout);
+          const featureResults: FeatureListItemType[] = [];
+          Object.keys(ansibleDocListJSONData).forEach((key) => {
+            featureResults.push({
+              name: key,
+              description: ansibleDocListJSONData[key],
+            });
+          });
+          resolve(featureResults);
+        } catch (e) {
+          resolve([]);
+        }
+      } else {
+        resolve([]);
+      }
+    });
+  });
+}
+
+async function runAnsibleDocShowSnippetsInTerminal(
+  pluginName: string,
+  ansibleDocPath: string,
+  choosedPluginType: string
+) {
+  const args: string[] = [];
+  args.push('-t', choosedPluginType);
+  args.push('-s');
+  args.push(pluginName);
+
+  if (terminal) {
+    if (terminal.bufnr) {
+      await workspace.nvim.command(`bd! ${terminal.bufnr}`);
+    }
+    terminal.dispose();
+    terminal = undefined;
+  }
+  terminal = await window.createTerminal({ name: 'ansibleDocShowSnippets', cwd: workspace.root });
+  terminal.sendText(`${ansibleDocPath} ${args.join(' ')}`);
+  const enableSplitRight = workspace.getConfiguration('ansible').get('ansibleDoc.enableSplitRight', true);
+  if (enableSplitRight) terminal.hide();
+  await workspace.nvim.command('stopinsert');
+  if (enableSplitRight) {
+    await workspace.nvim.command(`vert bel sb ${terminal.bufnr}`);
+    await workspace.nvim.command(`wincmd p`);
+  }
+}

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -117,6 +117,19 @@ export function getBuiltinToolPath(extensionStoragePath: string, toolName: strin
     }
   }
 
+  if (toolName === 'ansible-doc') {
+    if (
+      fs.existsSync(path.join(extensionStoragePath, 'ansible', 'venv', 'Scripts', 'ansible-doc.exe')) ||
+      fs.existsSync(path.join(extensionStoragePath, 'ansible', 'venv', 'bin', 'ansible-doc'))
+    ) {
+      if (process.platform === 'win32') {
+        toolPath = path.join(extensionStoragePath, 'ansible', 'venv', 'Scripts', 'ansible-doc.exe');
+      } else {
+        toolPath = path.join(extensionStoragePath, 'ansible', 'venv', 'bin', 'ansible-doc');
+      }
+    }
+  }
+
   return toolPath;
 }
 


### PR DESCRIPTION
## Description

Add feature to run the `ansible-doc` command in a terminal window with various options.

**Add Commands**:

- `ansible.ansbileDoc.showInfo`: Run the `ansible-doc` command in a terminal window with various options to display information about the plugins
- `ansible.ansbileDoc.showSnippets`: Run the `ansible-doc` command in a terminal window with various options to display a snippets of the plugins.

## Usage

1. Execute `:CocCommand ansible.ansbileDoc.showInfo` or `:CocCommand ansible.ansbileDoc.showSnippets`.
2. Choose Plugin Type.
3. A list of choosed plugin types will be displayed.
4. Narrow down the target plugin in the fuzzy finder (CocList) and press Enter.
5. Results are displayed in a terminal window
