### PR TITLE
feat(commands): add "ansible.server.showMetaData" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ You can also run the installation command manually.
       - `~/AppData/Local/coc/extensions/@yaegassy/coc-ansible-data/ansible/venv/Scripts/yamllint.exe`
   - **[Note]** `ansible` is a very large tool and will take some time to install
 - `ansible.server.restart`: Restart ansible language server
+- `ansible.server.showMetaData`: Show ansible-metadata for ansible language server
 - `ansible.ansbileDoc.showInfo`: Run the `ansible-doc` command in a terminal window with various options to display information about the plugins | [DEMO](https://github.com/yaegassy/coc-ansible/pull/22#issuecomment-1178586815)
 - `ansible.ansbileDoc.showSnippets`: Run the `ansible-doc` command in a terminal window with various options to display a snippets of the plugins | [DEMO](https://github.com/yaegassy/coc-ansible/pull/22#issuecomment-1178587359)
 

--- a/package.json
+++ b/package.json
@@ -348,6 +348,10 @@
         "title": "Restart ansible language server"
       },
       {
+        "command": "ansible.server.showMetaData",
+        "title": "Show ansible-metadata for ansible language server"
+      },
+      {
         "command": "ansible.ansbileDoc.showInfo",
         "title": "Run the `ansible-doc` command in a terminal window with various options to display information about the plugins"
       },

--- a/src/commands/serverShowMetaData.ts
+++ b/src/commands/serverShowMetaData.ts
@@ -1,0 +1,27 @@
+import { commands, ExtensionContext, LanguageClient, NotificationType, workspace } from 'coc.nvim';
+
+export async function activate(context: ExtensionContext, client: LanguageClient) {
+  await client.onReady();
+
+  client.onNotification(new NotificationType(`update/ansible-metadata`), async (ansibleMetaDataList: any) => {
+    const outputText = JSON.stringify(ansibleMetaDataList, null, 2);
+
+    await workspace.nvim
+      .command(
+        'belowright vnew ansible-server-metadata | setlocal buftype=nofile bufhidden=hide noswapfile filetype=json'
+      )
+      .then(async () => {
+        const buf = await workspace.nvim.buffer;
+        buf.setLines(outputText.split('\n'), { start: 0, end: -1 });
+      });
+  });
+
+  context.subscriptions.push(
+    commands.registerCommand('ansible.server.showMetaData', async () => {
+      const { document } = await workspace.getCurrentState();
+      if (document.languageId !== 'ansible') return;
+
+      client.sendNotification(new NotificationType(`update/ansible-metadata`), [document.uri.toString()]);
+    })
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import * as ansibleDocShowInfoCommandFeature from './commands/ansibleDocShowInfo
 import * as ansibleDocShowSnippetsCommandFeature from './commands/ansibleDocShowSnippets';
 import * as builtinInstallRequirementsToolsCommandFeature from './commands/builtinInstallRequirementsTools';
 import * as serverRestartCommandFeature from './commands/serverRestart';
+import * as serverShowMetaDataCommandFeature from './commands/serverShowMetaData';
 
 let client: LanguageClient;
 let extensionStoragePath: string;
@@ -180,6 +181,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   // commands
   serverRestartCommandFeature.activate(context, client);
+  serverShowMetaDataCommandFeature.activate(context, client);
   if (pythonCommandPaths) {
     builtinInstallRequirementsToolsCommandFeature.activate(context, pythonCommandPaths, client);
   }


### PR DESCRIPTION
## Description

Addd a command to display various information using the `update/ansible-metadata` notifications.

In `vscode-ansible`, it seems to be used in the status-bar.

- <https://github.com/ansible/vscode-ansible/pull/586>
- <https://github.com/ansible/ansible-language-server/pull/413>

## DEMO (mp4)

https://user-images.githubusercontent.com/188642/183790042-a434d0e1-43a1-4596-aeb6-4eeaff6aec5c.mp4
